### PR TITLE
이슈&알림 리스트에 swipe refresh 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,8 @@ dependencies {
     annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
 
     implementation "androidx.security:security-crypto:$security_crypto_version"
-
+    // paging 3
     implementation "androidx.paging:paging-runtime:3.1.1"
+    // swipe refresh
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 }

--- a/app/src/main/java/com/example/reposearchapp/di/ProvideAPI.kt
+++ b/app/src/main/java/com/example/reposearchapp/di/ProvideAPI.kt
@@ -34,7 +34,7 @@ fun buildOkhttpClient(): OkHttpClient {
     return OkHttpClient.Builder()
         .addInterceptor {
             val request = it.request().newBuilder()
-                .addHeader("Authorization", "bearer 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")
+                .addHeader("Authorization", "bearer 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")
                 .addHeader("Accept", "application/json")
                 .build()
             it.proceed(request)

--- a/app/src/main/java/com/example/reposearchapp/di/ProvideAPI.kt
+++ b/app/src/main/java/com/example/reposearchapp/di/ProvideAPI.kt
@@ -34,7 +34,7 @@ fun buildOkhttpClient(): OkHttpClient {
     return OkHttpClient.Builder()
         .addInterceptor {
             val request = it.request().newBuilder()
-                .addHeader("Authorization", "bearer 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")
+                .addHeader("Authorization", "bearer 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")
                 .addHeader("Accept", "application/json")
                 .build()
             it.proceed(request)

--- a/app/src/main/java/com/example/reposearchapp/presentation/home/issue/IssueFragment.kt
+++ b/app/src/main/java/com/example/reposearchapp/presentation/home/issue/IssueFragment.kt
@@ -48,6 +48,11 @@ class IssueFragment : BaseFragment<FragmentIssueBinding>(R.layout.fragment_issue
                 else R.drawable.background_issue_filter_unfocused
             )
         }
+
+        swipeRefreshLayout.setOnRefreshListener {
+            issueListAdapter.refresh()
+            swipeRefreshLayout.isRefreshing = false
+        }
     }
 
     private fun observeIssue() {
@@ -61,7 +66,9 @@ class IssueFragment : BaseFragment<FragmentIssueBinding>(R.layout.fragment_issue
         }
         // paging data
         lifecycleScope.launch {
-            viewModel.getIssues().collectLatest { issueListAdapter.submitData(it) }
+            viewModel.getIssues().collectLatest {
+                issueListAdapter.submitData(it)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/reposearchapp/presentation/home/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/example/reposearchapp/presentation/home/notification/NotificationFragment.kt
@@ -49,8 +49,11 @@ class NotificationFragment :
         itemTouchHelper.attachToRecyclerView(recyclerNotification)
     }
 
-    private fun bindViews() {
-
+    private fun bindViews() = with(binding) {
+        swipeRefreshLayout.setOnRefreshListener {
+            notificationAdapter.refresh()
+            swipeRefreshLayout.isRefreshing = false
+        }
     }
 
     private fun observeNotification() =

--- a/app/src/main/res/layout/fragment_issue.xml
+++ b/app/src/main/res/layout/fragment_issue.xml
@@ -20,7 +20,7 @@
             android:layout_marginVertical="14dp"
             android:background="@drawable/background_issue_filter_unfocused"
             android:padding="12dp"
-            app:layout_constraintBottom_toTopOf="@id/issueRecyclerView"
+            app:layout_constraintBottom_toTopOf="@id/swipe_refresh_layout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -63,17 +63,24 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/issueRecyclerView"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_issue_filter"
-            tools:itemCount="3"
-            tools:listitem="@layout/item_issue" />
+            app:layout_constraintTop_toBottomOf="@id/layout_issue_filter">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/issueRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:itemCount="3"
+                tools:listitem="@layout/item_issue" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -10,15 +10,22 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_notification"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_notification"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### Summary
홈 화면에 이슈와 알림 리스트에 Swipe Refresh 추가

### Main Changes
- 지난 코드 리뷰에서 리스트 정보를 새로 받아올 수 있는 이벤트의 필요성에 대한 이야기가 나와
해당 기능에 대한 코드를 추가하였습니다.
- SwipeRefreshLayout을 사용하여 구현하였으며, Swipe 시 PageDataAdapter의 refresh 메서드를 호출하는 방식으로 처리하였습니다.

### UseCase
1. 이슈 리스트를 띄워준다.
2. 이슈 하나를 closed하고, refresh하면 화면에서 사라지는 것을 볼 수 있습니다.
[Notification도 동일]

https://user-images.githubusercontent.com/22411296/180035955-479a123c-1f76-4777-99f6-54ed94c6c80e.mov

### Related Issue
Closes #39 
